### PR TITLE
Remove shebang

### DIFF
--- a/pynobo.py
+++ b/pynobo.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import asyncio
 import collections
 from contextlib import suppress


### PR DESCRIPTION
Modules don't need shebangs as they aren't executed directly.