### PR TITLE
Expose known device models

### DIFF
--- a/pynobo.py
+++ b/pynobo.py
@@ -165,15 +165,18 @@ class nobo:
         https://help.nobo.no/en/user-manual/before-you-start/what-is-a-transmitter/list-of-transmitters/
         """
 
-        THERMOSTAT = "thermostat"
+        THERMOSTAT_HEATER = "thermostat_heater"
+        THERMOSTAT_FLOOR = "thermostat_floor"
+        THERMOSTAT_ROOM = "thermostat_room"
         SWITCH = "switch"
+        SWITCH_OUTLET = "switch_outlet"
         CONTROL_PANEL = "control_panel"
-        UNKNOWN = "unkown"
+        UNKNOWN = "unknown"
 
         def __init__(
                 self,
                 model_id: str,
-                type: Union[THERMOSTAT, SWITCH, CONTROL_PANEL, UNKNOWN],
+                type: Union[THERMOSTAT_HEATER, THERMOSTAT_FLOOR, THERMOSTAT_ROOM, SWITCH, SWITCH_OUTLET, CONTROL_PANEL, UNKNOWN],
                 name: str,
                 *,
                 supports_comfort: bool = False,
@@ -199,7 +202,7 @@ class nobo:
             return self._name
 
         @property
-        def type(self) -> Union[THERMOSTAT, SWITCH, CONTROL_PANEL, UNKNOWN]:
+        def type(self) -> Union[THERMOSTAT_HEATER, THERMOSTAT_FLOOR, THERMOSTAT_ROOM, SWITCH, SWITCH_OUTLET, CONTROL_PANEL, UNKNOWN]:
             """Model type."""
             return self._type
 
@@ -226,31 +229,31 @@ class nobo:
     MODELS = {
         "120": Model("129", Model.SWITCH, "RS 700"),
         "121": Model("121", Model.SWITCH, "RSX 700"),
-        "130": Model("130", Model.SWITCH, "RCE 700"),
-        "160": Model("160", Model.THERMOSTAT, "R80 RDC 700"),
-        "165": Model("165", Model.THERMOSTAT, "R80 RDC 700 LST (GB)"),
-        "168": Model("168", Model.THERMOSTAT, "NCU-2R", supports_comfort=True, supports_eco=True),
-        "170": Model("170", Model.THERMOSTAT, "Serie 18, ewt touch", supports_comfort=True, supports_eco=True), # Not verified if temperature can be set remotely
-        "180": Model("180", Model.THERMOSTAT, "2NC9 700", supports_eco=True),
-        "182": Model("182", Model.THERMOSTAT, "R80 RSC 700 (5-24)", supports_eco=True),
-        "183": Model("182", Model.THERMOSTAT, "R80 RSC 700 (5-30)", supports_eco=True),
-        "184": Model("184", Model.THERMOSTAT, "NCU-1R", supports_eco=True),
-        "186": Model("186", Model.THERMOSTAT, "DCU-1R", supports_eco=True),
-        "190": Model("190", Model.THERMOSTAT, "Safir", supports_comfort=True, supports_eco=True, requires_control_panel=True),
-        "192": Model("192", Model.THERMOSTAT, "R80 TXF 700", supports_comfort=True, supports_eco=True, requires_control_panel=True),
-        "194": Model("194", Model.THERMOSTAT, "R80 RXC 700", supports_comfort=True, supports_eco=True),
-        "198": Model("198", Model.THERMOSTAT, "NCU-ER", supports_comfort=True, supports_eco=True),
-        "200": Model("200", Model.THERMOSTAT, "TRB 36 700"),
-        "210": Model("210", Model.THERMOSTAT, "NTB-2R", supports_comfort=True, supports_eco=True),
-        "220": Model("220", Model.THERMOSTAT, "TR36", supports_eco=True),
-        "230": Model("230", Model.THERMOSTAT, "TCU 700"),
-        "231": Model("231", Model.THERMOSTAT, "THB 700"),
-        "232": Model("232", Model.THERMOSTAT, "TXB 700"),
+        "130": Model("130", Model.SWITCH_OUTLET, "RCE 700"),
+        "160": Model("160", Model.THERMOSTAT_HEATER, "R80 RDC 700"),
+        "165": Model("165", Model.THERMOSTAT_HEATER, "R80 RDC 700 LST (GB)"),
+        "168": Model("168", Model.THERMOSTAT_HEATER, "NCU-2R", supports_comfort=True, supports_eco=True),
+        "169": Model("169", Model.THERMOSTAT_HEATER, "DCU-2R", supports_comfort=True, supports_eco=True),
+        "170": Model("170", Model.THERMOSTAT_HEATER, "Serie 18, ewt touch", supports_comfort=True, supports_eco=True), # Not verified if temperature can be set remotely
+        "180": Model("180", Model.THERMOSTAT_HEATER, "2NC9 700", supports_eco=True),
+        "182": Model("182", Model.THERMOSTAT_HEATER, "R80 RSC 700 (5-24)", supports_eco=True),
+        "183": Model("182", Model.THERMOSTAT_HEATER, "R80 RSC 700 (5-30)", supports_eco=True),
+        "184": Model("184", Model.THERMOSTAT_HEATER, "NCU-1R", supports_eco=True),
+        "186": Model("186", Model.THERMOSTAT_HEATER, "DCU-1R", supports_eco=True),
+        "190": Model("190", Model.THERMOSTAT_HEATER, "Safir", supports_comfort=True, supports_eco=True, requires_control_panel=True),
+        "192": Model("192", Model.THERMOSTAT_HEATER, "R80 TXF 700", supports_comfort=True, supports_eco=True, requires_control_panel=True),
+        "194": Model("194", Model.THERMOSTAT_HEATER, "R80 RXC 700", supports_comfort=True, supports_eco=True),
+        "198": Model("198", Model.THERMOSTAT_HEATER, "NCU-ER", supports_comfort=True, supports_eco=True),
+        "200": Model("200", Model.THERMOSTAT_FLOOR, "TRB 36 700"),
+        "210": Model("210", Model.THERMOSTAT_FLOOR, "NTB-2R", supports_comfort=True, supports_eco=True),
+        "220": Model("220", Model.THERMOSTAT_FLOOR, "TR36", supports_eco=True),
+        "230": Model("230", Model.THERMOSTAT_ROOM, "TCU 700"),
+        "231": Model("231", Model.THERMOSTAT_ROOM, "THB 700"),
+        "232": Model("232", Model.THERMOSTAT_ROOM, "TXB 700"),
         "234": Model("234", Model.CONTROL_PANEL, "SW4", has_temp_sensor=True),
     }
-    # Unknown serial prefix for these models:
-    # Model("", Model.THERMOSTAT, "DCU-2R", supports_comfort=True, supports_eco=True)
-    # Model("", Model.THERMOSTAT, "DCU-ER", supports_comfort=True, supports_eco=True)
+    # Unknown serial prefix for this model:
+    # Model("", Model.THERMOSTAT_HEATER, "DCU-ER", supports_comfort=True, supports_eco=True)
 
     class DiscoveryProtocol(asyncio.DatagramProtocol):
         """Protocol to discover Nobø Echohub on local network."""

--- a/pynobo.py
+++ b/pynobo.py
@@ -165,13 +165,13 @@ class nobo:
         https://help.nobo.no/en/user-manual/before-you-start/what-is-a-transmitter/list-of-transmitters/
         """
 
-        THERMOSTAT_HEATER = "thermostat_heater"
-        THERMOSTAT_FLOOR = "thermostat_floor"
-        THERMOSTAT_ROOM = "thermostat_room"
-        SWITCH = "switch"
-        SWITCH_OUTLET = "switch_outlet"
-        CONTROL_PANEL = "control_panel"
-        UNKNOWN = "unknown"
+        THERMOSTAT_HEATER = "THERMOSTAT_HEATER"
+        THERMOSTAT_FLOOR = "THERMOSTAT_FLOOR"
+        THERMOSTAT_ROOM = "THERMOSTAT_ROOM"
+        SWITCH = "SWITCH"
+        SWITCH_OUTLET = "SWITCH_OUTLET"
+        CONTROL_PANEL = "CONTROL_PANEL"
+        UNKNOWN = "UNKNOWN"
 
         def __init__(
                 self,
@@ -244,6 +244,7 @@ class nobo:
         "192": Model("192", Model.THERMOSTAT_HEATER, "R80 TXF 700", supports_comfort=True, supports_eco=True, requires_control_panel=True),
         "194": Model("194", Model.THERMOSTAT_HEATER, "R80 RXC 700", supports_comfort=True, supports_eco=True),
         "198": Model("198", Model.THERMOSTAT_HEATER, "NCU-ER", supports_comfort=True, supports_eco=True),
+        "199": Model("199", Model.THERMOSTAT_HEATER, "DCU-ER", supports_comfort=True, supports_eco=True),
         "200": Model("200", Model.THERMOSTAT_FLOOR, "TRB 36 700"),
         "210": Model("210", Model.THERMOSTAT_FLOOR, "NTB-2R", supports_comfort=True, supports_eco=True),
         "220": Model("220", Model.THERMOSTAT_FLOOR, "TR36", supports_eco=True),
@@ -252,8 +253,6 @@ class nobo:
         "232": Model("232", Model.THERMOSTAT_ROOM, "TXB 700"),
         "234": Model("234", Model.CONTROL_PANEL, "SW4", has_temp_sensor=True),
     }
-    # Unknown serial prefix for this model:
-    # Model("", Model.THERMOSTAT_HEATER, "DCU-ER", supports_comfort=True, supports_eco=True)
 
     class DiscoveryProtocol(asyncio.DatagramProtocol):
         """Protocol to discover Nobø Echohub on local network."""

--- a/pynobo.py
+++ b/pynobo.py
@@ -160,7 +160,7 @@ class nobo:
         """
         A device model that supports Nobø Ecohub.
 
-        Lists of devices:
+        Official lists of devices:
         https://help.nobo.no/en/user-manual/before-you-start/what-is-a-receiver/list-of-receivers/
         https://help.nobo.no/en/user-manual/before-you-start/what-is-a-transmitter/list-of-transmitters/
         """
@@ -175,15 +175,17 @@ class nobo:
                 model_id: str,
                 type: Union[THERMOSTAT, SWITCH, CONTROL_PANEL, UNKNOWN],
                 name: str,
-                set_comfort: bool=True,
-                set_eco: bool=True,
-                has_temp_sensor: bool=False
-        ):
+                *,
+                supports_comfort: bool = False,
+                supports_eco: bool = False,
+                requires_control_panel = False,
+                has_temp_sensor: bool = False):
             self._model_id = model_id
             self._type = type
             self._name = name
-            self._set_comfort = set_comfort
-            self._set_eco = set_eco
+            self._supports_comfort = supports_comfort
+            self._supports_eco = supports_eco
+            self._requires_control_panel = requires_control_panel
             self._has_temp_sensor = has_temp_sensor
 
         @property
@@ -202,14 +204,19 @@ class nobo:
             return self._type
 
         @property
-        def set_comfort(self) -> bool:
+        def supports_comfort(self) -> bool:
             """Return True if comfort temperature can be set on hub."""
-            return self._set_comfort
+            return self._supports_comfort
 
         @property
-        def set_eco(self) -> bool:
+        def supports_eco(self) -> bool:
             """Return True if eco temperature can be set on hub."""
-            return self._set_eco
+            return self._supports_eco
+
+        @property
+        def requires_control_panel(self) -> bool:
+            """Return True if setting temperature on hub requires a control panel in the zone."""
+            return self._requires_control_panel
 
         @property
         def has_temp_sensor(self) -> bool:
@@ -217,30 +224,33 @@ class nobo:
             return self._has_temp_sensor
 
     MODELS = {
-        "120": Model("129", Model.SWITCH, "RS 700", False, False),
-        "160": Model("160", Model.THERMOSTAT, "R80 RDC 700", False, False),
-        "168": Model("168", Model.THERMOSTAT, "NCU-2R"),
-        "182": Model("182", Model.THERMOSTAT, "R80 RSC 700", False),
-        "184": Model("184", Model.THERMOSTAT, "NCU-1R", False),
-        "192": Model("192", Model.THERMOSTAT, "TXF"),
-        "198": Model("198", Model.THERMOSTAT, "NCU-ER"),
-        "200": Model("200", Model.THERMOSTAT, "TRB 36 700", False, False),
-        "210": Model("210", Model.THERMOSTAT, "NTB-2R"),
-        "234": Model("234", Model.CONTROL_PANEL, "SW4", False, False, True),
+        "120": Model("129", Model.SWITCH, "RS 700"),
+        "121": Model("121", Model.SWITCH, "RSX 700"),
+        "130": Model("130", Model.SWITCH, "RCE 700"),
+        "160": Model("160", Model.THERMOSTAT, "R80 RDC 700"),
+        "165": Model("165", Model.THERMOSTAT, "R80 RDC 700 LST (GB)"),
+        "168": Model("168", Model.THERMOSTAT, "NCU-2R", supports_comfort=True, supports_eco=True),
+        "170": Model("170", Model.THERMOSTAT, "Serie 18, ewt touch", supports_comfort=True, supports_eco=True), # Not verified if temperature can be set remotely
+        "180": Model("180", Model.THERMOSTAT, "2NC9 700", supports_eco=True),
+        "182": Model("182", Model.THERMOSTAT, "R80 RSC 700 (5-24)", supports_eco=True),
+        "183": Model("182", Model.THERMOSTAT, "R80 RSC 700 (5-30)", supports_eco=True),
+        "184": Model("184", Model.THERMOSTAT, "NCU-1R", supports_eco=True),
+        "186": Model("186", Model.THERMOSTAT, "DCU-1R", supports_eco=True),
+        "190": Model("190", Model.THERMOSTAT, "Safir", supports_comfort=True, supports_eco=True, requires_control_panel=True),
+        "192": Model("192", Model.THERMOSTAT, "R80 TXF 700", supports_comfort=True, supports_eco=True, requires_control_panel=True),
+        "194": Model("194", Model.THERMOSTAT, "R80 RXC 700", supports_comfort=True, supports_eco=True),
+        "198": Model("198", Model.THERMOSTAT, "NCU-ER", supports_comfort=True, supports_eco=True),
+        "200": Model("200", Model.THERMOSTAT, "TRB 36 700"),
+        "210": Model("210", Model.THERMOSTAT, "NTB-2R", supports_comfort=True, supports_eco=True),
+        "220": Model("220", Model.THERMOSTAT, "TR36", supports_eco=True),
+        "230": Model("230", Model.THERMOSTAT, "TCU 700"),
+        "231": Model("231", Model.THERMOSTAT, "THB 700"),
+        "232": Model("232", Model.THERMOSTAT, "TXB 700"),
+        "234": Model("234", Model.CONTROL_PANEL, "SW4", has_temp_sensor=True),
     }
-    # Unknown serial prefix for this models:
-    # Model("", Model.THERMOSTAT, "DCU-1R", False)
-    # Model("", Model.THERMOSTAT, "DCU-2R")
-    # Model("", Model.THERMOSTAT, "DCU-ER")
-    # Model("", Model.THERMOSTAT, "R80 RXC 700")
-    # Model("", Model.THERMOSTAT, "R80 TXF 700") # Requires temperature sensor (SW4) in zone
-    # Model("", Model.THERMOSTAT, "2NC9 700", False)
-    # Model("", Model.THERMOSTAT, "TXB 700", False, False)
-    # Model("", Model.THERMOSTAT, "TR36", False)
-    # Model("", Model.THERMOSTAT, "TCU700", False, False)
-    # Model("", Model.THERMOSTAT, "Safir") # Requires temperature sensor (SW4) in zone
-    # Model("", Model.SWITCH, "RSX 700", False, False)
-    # Model("", Model.SWITCH, "RCE 700", False, False)
+    # Unknown serial prefix for these models:
+    # Model("", Model.THERMOSTAT, "DCU-2R", supports_comfort=True, supports_eco=True)
+    # Model("", Model.THERMOSTAT, "DCU-ER", supports_comfort=True, supports_eco=True)
 
     class DiscoveryProtocol(asyncio.DatagramProtocol):
         """Protocol to discover Nobø Echohub on local network."""
@@ -679,7 +689,7 @@ class nobo:
             else:
                 dicti['model'] = nobo.Model(
                     model_id,
-                    "Unknown",
+                    nobo.Model.UNKNOWN,
                     f'Unknown (serial number: {serial[:3]} {serial[3:6]} {serial[6:9]} {serial[9:]})'
                 )
             self.components[dicti['serial']] = dicti

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.2.0',
+    version='1.3.0',
     description='Nobø Hub / Nobø Energy Control TCP/IP Interface',
 
     license='GPLv3+',


### PR DESCRIPTION
This PR adds the model of a device to the API, if the serial prefix is known.

A model has the following read-only attributes:
* `model_id`: 3 digit serial prefix
* `type`: `THERMOSTAT`, `SWITCH`, `CONTROL_PANEL`, or `UNKNOWN`
* `name`
* `set_comfort`: True if the device supports setting comfort temperature from the hub
* `set_eco`: True if the device supports setting eco temperature from the hub
* `has_temp_sensor`: True if the device supports reporting temperature to the hub

The device model is accessed through the key `"model"` on a `component`.

The intention is to be able to
1. List all _devices_ in Home Assistant (not only _entities_).
   * Unknown devices are shown with their serial number in the name.
2. Expose switches and temperature sensors as separate entities in Home Assistant.
   * Note: It may make sense to differentiate between `OUTLET` and `SWITCH` for use in HA.
3. Possibly hide unsupported features in HA as discussed in https://github.com/echoromeo/hanobo/issues/16

List of all devices and features are available at:
* https://help.nobo.no/en/user-manual/before-you-start/what-is-a-receiver/list-of-receivers/
* https://help.nobo.no/en/user-manual/before-you-start/what-is-a-transmitter/list-of-transmitters/

Unfortunately I have not been able to get hold of serial prefixes for the following devices:
* DCU-1R
* DCU-2R
* DCU-ER
* R80 RXC 700
* R80 TXF 700
* 2NC9 700
* TXB 700
* TR36
* TCU700
* Safir
* RSX 700
* RCE 700

If anybody has any of these devices, I would be very grateful to get the 3 first digits of the serial number!