### PR TITLE
Convert to asyncio.get_running_loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ It is possible to discover hubs on the local network, and also test connectivity
 
     # Test connection to the first
     (serial, ip) = hubs.pop()
-    hub = nobo(serial + '123', ip, False, loop=asyncio.get_event_loop())
+    hub = nobo(serial + '123', ip=ip, discover=False, synchronous=False)
     await hub.async_connect_hub(ip=test_ip, serial=self.serial)
 
     # Then start the background tasks
@@ -88,7 +88,7 @@ These functions sends commands to the hub.
 
 ### Dictionary helper functions
 
-These functions simplifies getting the data you want from the dictionaries. They do
+These functions simplify getting the data you want from the dictionaries. They do
 not perform any I/O, and can safely be called from the event loop.
 
 * get_week_profile_status - Get the status of a week profile at a certain time in the week 
@@ -99,8 +99,8 @@ not perform any I/O, and can safely be called from the event loop.
 ## Backwards compatibility
 
 Synchronous wrapper methods are available for compatibility with v1.1.2, but it is recommended to
-switch to the async methods. If `loop` is not provided, initializing will start the async event
-loop in a daemon thread, discover and connect to hub before returning as before.
+switch to the async methods by initializing the hub with `synchronous=False`. Otherwise, initializing
+will start the async event loop in a daemon thread, discover and connect to hub before returning as before.
 
     import time
     from pynobo import nobo

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This system/service/software is not officially supported or endorsed by Glen Dim
 
     async def main():
         # Either call using the three last digits in the hub serial
-        hub = nobo('123', loop=asyncio.get_event_loop()) 
+        hub = nobo('123', synchronous=False)
         # or full serial and IP if you do not want to discover on UDP:
-        hub = nobo('123123123123', '10.0.0.128', False, loop=asyncio.get_event_loop())
+        hub = nobo('123123123123', ip='10.0.0.128', discover=False, synchronous=False)
 
         # Connect to the hub
         await hub.start()

--- a/pynobo.py
+++ b/pynobo.py
@@ -295,7 +295,7 @@ class nobo:
         Initialize logger and dictionaries.
 
         :param serial: The last 3 digits of the Ecohub serial number or the complete 12 digit serial number
-        :param ip: ip address to search for Ecohub at (default None)
+        :param ip: IP address to search for Ecohub at (default None)
         :param discover: True/false for using UDP autodiscovery for the IP (default True)
         :param loop: Deprecated
         :param synchronous: True/false for using the module synchronously. For backwards compatibility.
@@ -529,7 +529,9 @@ class nobo:
         _LOGGER.info('reconnected to Nobø Hub')
 
     @staticmethod
-    def discover_hubs(serial="", ip=None, autodiscover_wait=3.0):
+    def discover_hubs(serial="", ip=None, autodiscover_wait=3.0, loop=None):
+        if loop is not None:
+            _LOGGER.warning("loop is deprecated")
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -538,7 +540,7 @@ class nobo:
         return loop.run_until_complete(nobo.async_discover_hubs(serial, ip, autodiscover_wait))
 
     @staticmethod
-    async def async_discover_hubs(serial="", ip=None, autodiscover_wait=3.0, rediscover=False):
+    async def async_discover_hubs(serial="", ip=None, autodiscover_wait=3.0, loop=None, rediscover=False):
         """
         Attempt to autodiscover Nobø Ecohubs on the local network.
 
@@ -559,11 +561,14 @@ class nobo:
         :param serial: The last 3 digits of the Ecohub serial number or the complete 12 digit serial number
         :param ip: ip address to search for Ecohub at (default None)
         :param autodiscover_wait: how long to wait for an autodiscover package from the hub (default 3.0)
+        :param loop: deprecated
         :param rediscover: if true, run until the hub is discovered
 
         :return: a set of hubs matching that serial, ip address or both
         """
 
+        if loop is not None:
+            _LOGGER.warning("loop is deprecated.")
         transport, protocol = await asyncio.get_running_loop().create_datagram_endpoint(
             lambda: nobo.DiscoveryProtocol(serial, ip),
             local_addr=('0.0.0.0', 10000),

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.3.1',
+    version='1.4.0',
     description='Nobø Hub / Nobø Energy Control TCP/IP Interface',
 
     license='GPLv3+',
@@ -100,7 +100,7 @@ setup(
     # 'Programming Language' classifiers above, 'pip install' will check this
     # and refuse to install the project if the version does not match. See
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires='>=3.6, <4',
+    python_requires='>=3.7, <4',
 
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is


### PR DESCRIPTION
Convert to asyncio.get_running_loop as get_event_loop is deprecated in Python 3.10

This was pointed out in the review of https://github.com/home-assistant/core/pull/50913 and has to be fixed before Nobø Hub can be an official Home Assistant integration.

I'm a bit out on a limb here, as I don't know much about event loop and threading. It was very tempting to remove the backwards compatibility for synchronous calls, but my test script still runs fine.