### PR TITLE
New method get_zone_override_mode

### DIFF
--- a/pynobo.py
+++ b/pynobo.py
@@ -884,16 +884,16 @@ class nobo:
         current_mode = ''
 
         # check if the zone is overridden and to which mode
-        if self.zones[zone_id]['override_allowed'] == '1':
-            for o in self.overrides:
-                if self.overrides[o]['mode'] == '0':
-                    continue # "normal" overrides
-                elif self.overrides[o]['target_type'] == nobo.API.OVERRIDE_TARGET_ZONE:
-                    if self.overrides[o]['target_id'] == zone_id:
-                        current_mode = nobo.API.DICT_OVERRIDE_MODE_TO_NAME[self.overrides[o]['mode']]
-                        break
-                elif self.overrides[o]['target_type'] == nobo.API.OVERRIDE_TARGET_GLOBAL:
+        for o in self.overrides:
+            if self.overrides[o]['mode'] == '0':
+                continue # "normal" overrides
+            elif self.overrides[o]['target_type'] == nobo.API.OVERRIDE_TARGET_ZONE:
+                if self.overrides[o]['target_id'] == zone_id:
                     current_mode = nobo.API.DICT_OVERRIDE_MODE_TO_NAME[self.overrides[o]['mode']]
+                    break # Takes precedence over global override
+            elif (self.zones[zone_id]['override_allowed'] == '1'
+                  and self.overrides[o]['target_type'] == nobo.API.OVERRIDE_TARGET_GLOBAL):
+                current_mode = nobo.API.DICT_OVERRIDE_MODE_TO_NAME[self.overrides[o]['mode']]
 
         # no override - find mode from week profile
         if not current_mode:

--- a/pynobo.py
+++ b/pynobo.py
@@ -887,10 +887,10 @@ class nobo:
         for o in self.overrides:
             if self.overrides[o]['mode'] == '0':
                 continue # "normal" overrides
-            elif self.overrides[o]['target_type'] == nobo.API.OVERRIDE_TARGET_ZONE:
-                if self.overrides[o]['target_id'] == zone_id:
-                    current_mode = nobo.API.DICT_OVERRIDE_MODE_TO_NAME[self.overrides[o]['mode']]
-                    break # Takes precedence over global override
+            elif (self.overrides[o]['target_type'] == nobo.API.OVERRIDE_TARGET_ZONE
+                  and self.overrides[o]['target_id'] == zone_id):
+                current_mode = nobo.API.DICT_OVERRIDE_MODE_TO_NAME[self.overrides[o]['mode']]
+                break # Takes precedence over global override
             elif (self.zones[zone_id]['override_allowed'] == '1'
                   and self.overrides[o]['target_type'] == nobo.API.OVERRIDE_TARGET_GLOBAL):
                 current_mode = nobo.API.DICT_OVERRIDE_MODE_TO_NAME[self.overrides[o]['mode']]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.4.1',
+    version='1.5.0',
     description='Nobø Hub / Nobø Energy Control TCP/IP Interface',
 
     license='GPLv3+',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.4.0',
+    version='1.4.1',
     description='Nobø Hub / Nobø Energy Control TCP/IP Interface',
 
     license='GPLv3+',


### PR DESCRIPTION
Moved logic to get zone override mode into a separate method, as this is useful for e.g. HA integration.

This PR contains the fix in PR #27, but bumps the minor version, as it introduces a new public method.