### PR TITLE
connect() as separate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This system/service/software is not officially supported or endorsed by Glen Dim
             print(hub.overrides)
             print(hub.temperatures)
     
-        # Get initial data
+        # Read the initial data
         update(hub)
     
         # Listen for data updates - register before getting initial data to avoid race condition

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This system/service/software is not officially supported or endorsed by Glen Dim
         # or full serial and IP if you do not want to discover on UDP:
         hub = nobo('123123123123', ip='10.0.0.128', discover=False, synchronous=False)
 
-        # Connect to the hub
-        await hub.start()
+        # Connect to the hub and get initial data
+        await hub.connect()
 
         # Inspect what you get
         def update(hub):
@@ -29,12 +29,16 @@ This system/service/software is not officially supported or endorsed by Glen Dim
             print(hub.overrides)
             print(hub.temperatures)
     
-        # Listen for data updates - register before getting initial data to avoid race condition
-        hub.register_callback(callback=update)
-
         # Get initial data
         update(hub)
     
+        # Listen for data updates - register before getting initial data to avoid race condition
+        hub.register_callback(callback=update)
+
+        # Start the background tasks for reading responses and keep connction alive
+        # This will connect to the hub if necessary
+        await hub.start()
+
         # Hang around and wait for data updates
         await asyncio.sleep(60)
     
@@ -59,7 +63,7 @@ It is possible to discover hubs on the local network, and also test connectivity
     # Test connection to the first
     (serial, ip) = hubs.pop()
     hub = nobo(serial + '123', ip=ip, discover=False, synchronous=False)
-    await hub.async_connect_hub(ip=test_ip, serial=self.serial)
+    await hub.connect()
 
     # Then start the background tasks
     await hub.start()
@@ -80,7 +84,7 @@ If the connection is lost, it will attempt to reconnect.
 
 ### Command Functions
 
-These functions sends commands to the hub.
+These functions send commands to the hub.
 
 * async_send_command - Send a list of command string(s) to the hub
 * async_create_override - Override hub/zones/components
@@ -95,6 +99,7 @@ not perform any I/O, and can safely be called from the event loop.
 * get_current_zone_mode - Get the mode of a zone at a certain time
 * get_current_component_temperature - Get the current temperature from a component
 * get_current_zone_temperature - Get the current temperature from (the first component in) a zone
+* get_zone_override_mode - Get the override mode for the zone
 
 ## Backwards compatibility
 

--- a/pynobo.py
+++ b/pynobo.py
@@ -356,7 +356,7 @@ class nobo:
         self._callbacks.remove(callback)
 
     async def connect(self):
-        """Connect to Ecoub, either by scanning or directly."""
+        """Connect to Ecohub, either by scanning or directly."""
         connected = False
         if self.discover:
             _LOGGER.info('Looking for Nobø Ecohub with serial: %s and ip: %s', self.serial, self.ip)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.5.0',
+    version='1.5.1',
     description='Nobø Hub / Nobø Energy Control TCP/IP Interface',
 
     license='GPLv3+',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.5.1',
+    version='1.6.0',
     description='Nobø Hub / Nobø Energy Control TCP/IP Interface',
 
     license='GPLv3+',


### PR DESCRIPTION
Required for https://github.com/home-assistant/core/pull/78480 so it is possible to connect to the hub and get the initial data required to instantiate the platforms before the background task that reads from the socket is started.