### PR TITLE
Fix get_current_zone_mode for 'now'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This system/service/software is not officially supported or endorsed by Glen Dim
         # Read the initial data
         update(hub)
     
-        # Listen for data updates - register before getting initial data to avoid race condition
+        # Listen for data updates - register before calling hub.start() to avoid race condition
         hub.register_callback(callback=update)
 
         # Start the background tasks for reading responses and keep connction alive

--- a/pynobo.py
+++ b/pynobo.py
@@ -898,7 +898,7 @@ class nobo:
         _LOGGER.debug('Current override for zone %s is %s', self.zones[zone_id]['name'], mode)
         return mode
 
-    def get_current_zone_mode(self, zone_id, now=datetime.datetime.today()):
+    def get_current_zone_mode(self, zone_id, now=None):
         """
         Get the mode of a zone at a certain time. If the zone is overridden only now is possible.
 
@@ -907,6 +907,8 @@ class nobo:
 
         :return: the mode for the zone
         """
+        if now is None:
+            now = datetime.datetime.today()
         current_time = (now.hour*100) + now.minute
         current_mode = self.get_zone_override_mode(zone_id)
         if current_mode == nobo.API.NAME_NORMAL:

--- a/pynobo.py
+++ b/pynobo.py
@@ -775,7 +775,7 @@ class nobo:
         elif response[0] == nobo.API.RESPONSE_REMOVE_OVERRIDE:
             dicti = collections.OrderedDict(zip(nobo.API.STRUCT_KEYS_OVERRIDE, response[1:]))
             self.overrides.pop(dicti['override_id'], None)
-            _LOGGER.info('removed override: id%s', dicti['override_id'])
+            _LOGGER.info('removed override: %s', dicti['override_id'])
 
         # Component temperature data
         elif response[0] == nobo.API.RESPONSE_COMPONENT_TEMP:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.6.0',
+    version='1.6.1',
     description='Nobø Hub / Nobø Energy Control TCP/IP Interface',
 
     license='GPLv3+',


### PR DESCRIPTION
I discovered that zones do not change mode in HA when following a week profile.

The reason is that the default value of 'now' got initialised when the script is loaded, and not on each call.