### PR TITLE
Version 1.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pynobo"
-version = "1.8.1"
+version = "1.9.0"
 description = "Nobø Hub / Nobø Energy Control TCP/IP Interface"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.8.1',
+    version='1.9.0',
     description='Nobø Hub / Nobø Energy Control TCP/IP Interface',
 
     license='GPLv3+',


### PR DESCRIPTION
Need a release to be able to bring the [Home Assistant integration](https://www.home-assistant.io/integrations/nobo_hub/)  past bronze on the [Home Assistance quality scale](https://www.home-assistant.io/docs/quality_scale/). This version should include everything needed for all the way to 🏆 platinum. (Currently silver is blocked by missing connection-state API.)

Requires PRs #39, #40, and #43 to be merged first.

Release 1.9.0 contains:
- Typed package with `py.typed`, exception hierarchy, and `DeprecationWarning` on synchronous use.
- Connection-state API: `hub.connected`, `register_connection_callback`, `deregister_connection_callback`
- `TypedDicts` and `mypy --strict` cleanup
- `pyproject.toml` (PEP 621), minimum Python 3.10, CI matrix 3.10-3.14.